### PR TITLE
fix bug in export model

### DIFF
--- a/export_model.py
+++ b/export_model.py
@@ -34,7 +34,7 @@ class ModelExporter(object):
     with tf.Graph().as_default() as graph:
       self.inputs, self.outputs = self.build_inputs_and_outputs()
       self.graph = graph
-      self.saver = tf.train.Saver(tf.trainable_variables(), sharded=True)
+      self.saver = tf.train.Saver(sharded=True)
 
   def export_model(self, model_dir, global_step_val, last_checkpoint):
     """Exports the model so that it can used for batch predictions."""


### PR DESCRIPTION
We should save all variables, especially those mean and vars in batch_norm, instead of only saving the trainable_variables.
So that we can correctly restore the model from the savedmodel and do the inference